### PR TITLE
feat: add default icons to chatbot

### DIFF
--- a/src/providers/ChatbotProvider.tsx
+++ b/src/providers/ChatbotProvider.tsx
@@ -11,12 +11,15 @@ import { ConfigurationType, ConversationType } from "@shared/ts/type";
 import { db } from "@constants/firebase/config";
 import { chatbotConfig } from "@constants/bot/chatbot-config";
 
+// assets
+import ChatbotLogo from "@static/assets/images/logo.png";
+
 const botProfileCollectionRef = collection(db, "profile");
 
 const ChatbotProvider = ({ children }: { children: React.ReactNode }) => {
   const [configuration, setConfiguration] = useState<ConfigurationType>({
-    icon: "",
-    widgetIcon: "",
+    icon: ChatbotLogo,
+    widgetIcon: ChatbotLogo,
     name: chatbotConfig.name,
     slogan: chatbotConfig.slogan,
   });


### PR DESCRIPTION
# Type of Change

- [ ] BREAKING CHANGE (change that would cause existing functionality to not work as expected)
- [x] Feature (change that implements a new feature)
- [x] Bug Fix (change that fixed a bug)
- [ ] Improvements (change that improves existing features or performance)
- [ ] Documentation (change in documents)
- [ ] Chore (formatting, refactoring, styling or other operations commit)

###

# Description

In order to show to chathead immediately, I use a default image for icons instead of waiting for the fetch one

###

# Related Tickets

- Fixes #176 