### PR TITLE
fix: text in rating cannot is not visible in dark mode

### DIFF
--- a/src/layouts/BotProfile.tsx
+++ b/src/layouts/BotProfile.tsx
@@ -60,7 +60,7 @@ const BotProfile = ({ className }: BotProfileProps) => {
             {chatbotConfig.about}
           </p>
           <div className="flex flex-col items-center gap-2">
-            <h2 className="max-w-[200px] md:max-w-[300px] lg:max-w-[400px]">
+            <h2 className="max-w-[200px] md:max-w-[300px] lg:max-w-[400px] text-black/80 dark:text-white/80">
               {rating != 0
                 ? `Your rating to ${configuration.name}`
                 : `Enjoying talking to ${configuration.name} so far? Please give us a


### PR DESCRIPTION
# Type of Change

<!-- Check what's necessary or check all if applicable. -->

- [ ] BREAKING CHANGE (change that would cause existing functionality to not work as expected)
- [ ] Feature (change that implements a new feature)
- [x] Bug Fix (change that fixed a bug)
- [ ] Improvements (change that improves existing features or performance)
- [ ] Documentation (change in documents)
- [ ] Chore (formatting, refactoring, styling or other operations commit)

###

# Description

Simple fix to the text in rating in bot profile that cannot be seen in dark mode due to lack of dark mode text styling