### PR TITLE
feat: add uid checking on what should render in landing page

### DIFF
--- a/src/app/CityHall.tsx
+++ b/src/app/CityHall.tsx
@@ -4,6 +4,7 @@ import { useContext } from "react";
 import { ChatContext } from "@contexts/ChatContext";
 
 // providers
+import UserProvider from "@providers/UserProvider";
 import FontProvider from "@providers/FontProvider";
 import SoundProvider from "@providers/SoundProvider";
 
@@ -18,6 +19,9 @@ import CityHallUI from "@layouts/CityHallUI";
 import ScreenDim from "@components/ScreenDim";
 import RatingBox from "@features/ratings/RatingBox";
 
+// utils
+import PageTitle from "@utils/page-title";
+
 const CityHall = () => {
   const chat = useContext(ChatContext);
   const { isChatActive, setIsChatActive } = chat.active;
@@ -29,24 +33,27 @@ const CityHall = () => {
 
   return (
     <>
-      <main className="">
-        <div ref={chatHead}>
-          <FontProvider>
-            <SoundProvider>
-              <ChatHead onClick={toggleChat} />
-              <ChatBox closeUsing={toggleChat} />
-            </SoundProvider>
-          </FontProvider>
-        </div>
-        <CityHallUI />
-        <ScreenDim
-          message="Click anywhere to close."
-          className={`bg-black z-40 backdrop-blur ${
-            isChatActive ? "opacity-80" : "opacity-0 invisible"
-          }`}
-        />
-        {isChatActive && <RatingBox />}
-      </main>
+      <PageTitle title="Bacoor Government Center | Bacoor Chatbot" />
+      <UserProvider>
+        <main className="">
+          <div ref={chatHead}>
+            <FontProvider>
+              <SoundProvider>
+                <ChatHead onClick={toggleChat} />
+                <ChatBox closeUsing={toggleChat} />
+              </SoundProvider>
+            </FontProvider>
+          </div>
+          <CityHallUI />
+          <ScreenDim
+            message="Click anywhere to close."
+            className={`bg-black z-40 backdrop-blur ${
+              isChatActive ? "opacity-80" : "opacity-0 invisible"
+            }`}
+          />
+          {isChatActive && <RatingBox />}
+        </main>
+      </UserProvider>
     </>
   );
 };

--- a/src/app/CityHall.tsx
+++ b/src/app/CityHall.tsx
@@ -33,9 +33,9 @@ const CityHall = () => {
 
   return (
     <>
-      <PageTitle title="Bacoor Government Center | Bacoor Chatbot" />
+      <PageTitle title="Bacoor Government Center | City of Bacoor Chatbot" />
       <UserProvider>
-        <main className="">
+        <main>
           <div ref={chatHead}>
             <FontProvider>
               <SoundProvider>

--- a/src/app/Error.tsx
+++ b/src/app/Error.tsx
@@ -29,7 +29,7 @@ const Error = () => {
             size="full"
             className="bg-primary hover:bg-primary-dark text-white uppercase"
           >
-            go to homepage
+            go back
           </Button>
         </Link>
       </div>

--- a/src/layouts/BotProfile.tsx
+++ b/src/layouts/BotProfile.tsx
@@ -1,11 +1,9 @@
 import { useContext } from "react";
-import { Link } from "react-router-dom";
 
 // context
 import { ChatbotContext } from "@contexts/ChatbotContext";
 
 // components
-import Button from "@components/ui/Button";
 import Image from "@components/ui/Image";
 import AverageRating from "@features/ratings/AverageRating";
 
@@ -70,15 +68,6 @@ const BotProfile = ({ className }: BotProfileProps) => {
           </div>
         </div>
       </div>
-      <Link to="/" className="mb-8">
-        <Button
-          variant="cta"
-          size="xl"
-          className="text-sm border border-surface dark:border-dm-surface bg-surface dark:bg-dm-surface hover:bg-primary dark:hover:bg-primary dark:text-white hover:text-white"
-        >
-          back to homepage
-        </Button>
-      </Link>
       <hr className="w-full border-surface-dark dark:border-dm-surface-light" />
     </section>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,6 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 // providers
 import ChatbotProvider from "@providers/ChatbotProvider";
-import UserProvider from "@providers/UserProvider";
 import AuthProvider from "@providers/AuthProvider";
 import ThemeProvider from "@providers/ThemeProvider";
 import ChatProvider from "@providers/ChatProvider";
@@ -21,27 +20,26 @@ import "@styles/custom-media-query.css";
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <Home />,
+    element: localStorage.getItem("uid") ? <CityHall /> : <Home />,
     errorElement: <Error />,
   },
   {
     path: "/bacoor-gov",
     element: <CityHall />,
+    errorElement: <Error />,
   },
 ]);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ChatbotProvider>
-      <UserProvider>
-        <AuthProvider>
-          <ThemeProvider>
-            <ChatProvider>
-              <RouterProvider router={router} />
-            </ChatProvider>
-          </ThemeProvider>
-        </AuthProvider>
-      </UserProvider>
+      <AuthProvider>
+        <ThemeProvider>
+          <ChatProvider>
+            <RouterProvider router={router} />
+          </ChatProvider>
+        </ThemeProvider>
+      </AuthProvider>
     </ChatbotProvider>
   </StrictMode>,
 );

--- a/src/utils/page-title.ts
+++ b/src/utils/page-title.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const PageTitle = ({ title }: { title: string }) => {
+  const location = useLocation();
+
+  useEffect(() => {
+    document.title = title;
+  }, [location, title]);
+
+  return null;
+};
+
+export default PageTitle;


### PR DESCRIPTION
# Type of Change

<!-- Check what's necessary or check all if applicable. -->

- [ ] BREAKING CHANGE (change that would cause existing functionality to not work as expected)
- [x] Feature (change that implements a new feature)
- [ ] Bug Fix (change that fixed a bug)
- [x] Improvements (change that improves existing features or performance)
- [ ] Documentation (change in documents)
- [x] Chore (formatting, refactoring, styling or other operations commit)

###

# Description

Since whenever visiting the page, the landing page is getting a bit repetitive, let's add a checking based on uid on what should we render on the landing page.

First time users gets the original landing page since uid hasn't been generated there but once they go the the unofficial page of the city hall, uid generates. Therefore, whenever we visit the page again, the original landing page will always be replaced by the unofficial page. This will reduce redundant clicks.