### PR TITLE
fix: video controls are hidden on small screens

### DIFF
--- a/src/features/chat/layouts/ChatLayout.tsx
+++ b/src/features/chat/layouts/ChatLayout.tsx
@@ -214,7 +214,7 @@ const ChatLayout = ({
                 <video
                   controls
                   muted
-                  className="w-max max-w-[50%] sm:max-w-[40%] md:max-w-[35%] lg:max-w-[30%] xl:max-w-[50%] max-h-max rounded-xl outline-primary object-contain cursor-pointer"
+                  className="w-max max-w-[70%] md:max-w-[60%] max-h-max rounded-xl outline-primary object-contain cursor-pointer"
                 >
                   <source src={video} type="video/mp4" />
                 </video>


### PR DESCRIPTION
# Type of Change

<!-- Check what's necessary or check all if applicable. -->

- [ ] BREAKING CHANGE (change that would cause existing functionality to not work as expected)
- [ ] Feature (change that implements a new feature)
- [x] Bug Fix (change that fixed a bug)
- [ ] Improvements (change that improves existing features or performance)
- [ ] Documentation (change in documents)
- [ ] Chore (formatting, refactoring, styling or other operations commit)

###

# Description

Since video layout on small screens are small, controls are hidden. Adjusted the max width for video layouts to fix this