### PR TITLE
fix: full timestamp can still be cursored

### DIFF
--- a/src/features/chat/layouts/ChatLayout.tsx
+++ b/src/features/chat/layouts/ChatLayout.tsx
@@ -221,7 +221,7 @@ const ChatLayout = ({
               )}
             </div>
             <span
-              className={`${isFullTimestampShowing ? "h-max mt-1" : "h-0 opacity-0"} text-xs ml-12 text-black/50 dark:text-white/50`}
+              className={`${isFullTimestampShowing ? "h-max mt-1" : "h-0 opacity-0 invisible"} text-xs ml-12 text-black/50 dark:text-white/50`}
             >
               {fullTimestamp}
             </span>
@@ -243,7 +243,7 @@ const ChatLayout = ({
               </ChatBubble>
             </div>
             <span
-              className={`${isFullTimestampShowing ? "h-max mt-1" : "h-0 opacity-0"} text-xs mr-1 text-black/50 dark:text-white/50`}
+              className={`${isFullTimestampShowing ? "h-max mt-1" : "h-0 opacity-0 invisible"} text-xs mr-1 text-black/50 dark:text-white/50`}
             >
               {fullTimestamp}
             </span>


### PR DESCRIPTION
# Type of Change

<!-- Check what's necessary or check all if applicable. -->

- [ ] BREAKING CHANGE (change that would cause existing functionality to not work as expected)
- [ ] Feature (change that implements a new feature)
- [x] Bug Fix (change that fixed a bug)
- [ ] Improvements (change that improves existing features or performance)
- [ ] Documentation (change in documents)
- [ ] Chore (formatting, refactoring, styling or other operations commit)

###

# Description

Full timestamp under chats can still be cursored meaning that its still there, its just 0 opacity. Fixed it by adding invisible when full timestamp is inactive