### PR TITLE
fix: chat head checking to make use of chat skeleton screens

### DIFF
--- a/src/features/chat/components/ChatSkeleton.tsx
+++ b/src/features/chat/components/ChatSkeleton.tsx
@@ -21,20 +21,19 @@ const ChatSkeleton = () => {
   ];
 
   return (
-    <section id="messages">
+    <section>
       <ItemsRenderer
         items={skeletonizedChat}
         renderItems={(skeletonizedChat, i) => (
-          <SkeletonScreen
+          <div
             key={i}
-            variant="chat"
             className={`${
-              skeletonizedChat.role == "bot"
-                ? "bot chat flex items-center gap-2"
-                : "user chat flex justify-end ml-auto"
+              skeletonizedChat.role === "bot"
+                ? "bot-chat flex items-center gap-2"
+                : "user-chat flex justify-end ml-auto"
             } mt-3 mb-2`}
           >
-            {skeletonizedChat.role == "bot" && (
+            {skeletonizedChat.role === "bot" && (
               <SkeletonScreen
                 variant="icon"
                 className="bg-surface dark:bg-dm-surface w-[35px] h-[35px] rounded-full select-none"
@@ -44,12 +43,12 @@ const ChatSkeleton = () => {
               id="chat"
               variant="chat"
               className={`${
-                skeletonizedChat.role == "bot"
+                skeletonizedChat.role === "bot"
                   ? "bg-surface dark:bg-dm-surface w-full h-[96px]"
-                  : "bg-primary w-[216px] h-[64px]"
+                  : "bg-primary w-[300px] h-[68px]"
               } `}
             />
-          </SkeletonScreen>
+          </div>
         )}
       />
     </section>

--- a/src/features/chat/components/sections/ChatSection.tsx
+++ b/src/features/chat/components/sections/ChatSection.tsx
@@ -139,7 +139,7 @@ const ChatSection = ({
       >
         <BotMiniProfile className="mb-8" miniProfileRef={miniProfileRef} />
         {loadingMoreChats && <Loading />}
-        {conversation ? (
+        {conversation.length ? (
           <div id="chats" ref={chatAreaRef}>
             {renderChatsContent()}
             {isBotTyping && <Typing />}

--- a/src/features/chat/layouts/ChatHead.tsx
+++ b/src/features/chat/layouts/ChatHead.tsx
@@ -5,9 +5,6 @@ import { AuthContext } from "@contexts/AuthContext";
 import { ChatContext } from "@contexts/ChatContext";
 import { ChatbotContext } from "@contexts/ChatbotContext";
 
-// hooks
-import useChatbot from "@hooks/useChatbot";
-
 // components
 import Loading from "@components/Loading";
 
@@ -16,18 +13,13 @@ const ChatHead = ({ onClick }: { onClick: () => void }) => {
   const { isSignedIn } = auth.user;
   const chatbot = useContext(ChatbotContext);
   const { configuration } = chatbot.configuration;
-  const { conversation } = chatbot.conversation;
   const chat = useContext(ChatContext);
   const { isChatActive } = chat.active;
   const { chatHeadSize } = chat.chatHeadSize;
-  const { isAtLatestChat } = useChatbot();
 
   return (
     <>
-      {isSignedIn &&
-      conversation.length != 0 &&
-      isAtLatestChat &&
-      configuration.widgetIcon ? (
+      {isSignedIn && configuration.widgetIcon ? (
         <button
           onClick={onClick}
           id=""

--- a/src/hooks/useChatbot.ts
+++ b/src/hooks/useChatbot.ts
@@ -10,7 +10,6 @@ import { v4 as uuid } from "uuid";
 
 // contexts
 import { ChatbotContext } from "@contexts/ChatbotContext";
-import { AuthContext } from "@contexts/AuthContext";
 import { UserContext } from "@contexts/UserContext";
 
 // constants
@@ -53,8 +52,6 @@ import { chatType, deptsType } from "@shared/ts/type";
 import { usersCollectionRef } from "@shared/collection-refs";
 
 const useChatbot = () => {
-  const auth = useContext(AuthContext);
-  const { isSignedIn } = auth.user;
   const user = useContext(UserContext);
   const chatbot = useContext(ChatbotContext);
   const { configuration } = chatbot.configuration;
@@ -65,7 +62,6 @@ const useChatbot = () => {
   const { isBotTyping, setIsBotTyping } = chatbot.isTyping;
   const { playMessageNotification } = useSound();
   const latestChat = useRef<HTMLDivElement | null>(null);
-  const [isAtLatestChat, setIsAtLatestChat] = useState<boolean>(false);
   const questionsListRef = useRef<HTMLDivElement | null>(null);
   const [settings, setSettings] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
@@ -280,9 +276,8 @@ const useChatbot = () => {
 
   // for auto scrolling
   useEffect(() => {
-    const atLatestChat = smoothScrollInto(latestChat);
-    if (isSignedIn && atLatestChat) setIsAtLatestChat(true);
-  }, [conversation, isBotTyping, error, isOnline, isSignedIn]);
+    smoothScrollInto(latestChat);
+  }, [conversation.length, isBotTyping, error, isOnline]);
 
   // for handling faqs menu on mouse down
   useEffect(() => {
@@ -311,7 +306,6 @@ const useChatbot = () => {
   }, [getConversationHistory]);
 
   return {
-    isAtLatestChat,
     latestChat,
     questionsListRef,
     settings,

--- a/src/lib/variants/skeleton-screen-variants.ts
+++ b/src/lib/variants/skeleton-screen-variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const skeletonScreenVariants = cva(
-  "w-full h-full animate-pulse bg-surface-dark dark:bg-dm-surface-light rounded pointer-events-none",
+  "w-full h-full animate-pulse rounded pointer-events-none",
   {
     variants: {
       variant: {


### PR DESCRIPTION
# Type of Change

<!-- Check what's necessary or check all if applicable. -->

- [ ] BREAKING CHANGE (change that would cause existing functionality to not work as expected)
- [ ] Feature (change that implements a new feature)
- [x] Bug Fix (change that fixed a bug)
- [x] Improvements (change that improves existing features or performance)
- [ ] Documentation (change in documents)
- [x] Chore (formatting, refactoring, styling or other operations commit)

###

# Description

Since before, we're checking if the chatbot is at the latest chat. The chat skeleton screen is being useless. Updated the checking in the chat head so it will appear immediately and while the conversation.length is still 0, chat skeleton screen will handle the supposed ui.