### PR TITLE
fix: cannot handle both link and file response

### DIFF
--- a/src/hooks/useChatbot.ts
+++ b/src/hooks/useChatbot.ts
@@ -31,6 +31,7 @@ import { userPost } from "@lib/user";
 import {
   processDepartmentServicesResponse,
   processFileResponse,
+  processFileWithLinkResponse,
   processLinkResponse,
 } from "@lib/process-response";
 import postQuery from "@lib/post-query";
@@ -44,7 +45,7 @@ import {
   hasLinkSymbol,
 } from "@utils/symbol-checker";
 import { smoothScrollInto } from "@utils/scroll-into";
-import { extractLink } from "@utils/extract-link";
+import { extractLink, extractMultipleLink } from "@utils/extract-link";
 import { extractFileNameFromUrl } from "@utils/extract-file-name-from-url";
 
 // shared
@@ -146,6 +147,39 @@ const useChatbot = () => {
                   role: "bot",
                   timestamp: Timestamp.now(),
                 };
+                setIsBotTyping(false);
+                userPost(user.uid, chatData);
+                setIsFaqsMenuActive(false);
+                playMessageNotification();
+              },
+            );
+          } else if (hasLinkSymbol(answer) && hasFileSymbol(answer)) {
+            const { link, fileLink } = extractMultipleLink(answer);
+
+            const fileName = fileLink ? extractFileNameFromUrl(fileLink) : "";
+            const fileExtension = fileName?.split(".")[1];
+
+            const fileWithLinkResponse: string[] =
+              link && fileLink ? [link, fileLink] : [];
+
+            fileWithLinkResponse.forEach(
+              async (response: string, i: number) => {
+                console.log(response);
+                if (i == 1) {
+                  await sleep(1);
+                  setIsBotTyping(true);
+                  await sleep(1);
+                }
+                chatData = fileExtension
+                  ? processFileWithLinkResponse(
+                      intent,
+                      response,
+                      link,
+                      fileLink,
+                      fileName,
+                      fileExtension,
+                    )
+                  : chatData;
                 setIsBotTyping(false);
                 userPost(user.uid, chatData);
                 setIsFaqsMenuActive(false);

--- a/src/lib/process-response.ts
+++ b/src/lib/process-response.ts
@@ -120,3 +120,77 @@ export const processDepartmentServicesResponse = (
   }
   return chatData;
 };
+
+export const processFileWithLinkResponse = (
+  intent: string,
+  response: string,
+  link: string,
+  fileLink: string,
+  fileName: string,
+  fileExtension: string,
+): chatType => {
+  if (images.includes(fileExtension)) {
+    if (response === link) {
+      chatData = {
+        intent: intent,
+        link: link,
+        chat: null,
+        chatId: uuid(),
+        role: "bot",
+        timestamp: Timestamp.now(),
+      };
+    } else {
+      chatData = {
+        intent: intent,
+        image: fileLink,
+        chat: null,
+        chatId: uuid(),
+        role: "bot",
+        timestamp: Timestamp.now(),
+      };
+    }
+  } else if (videos.includes(fileExtension)) {
+    if (response === link) {
+      chatData = {
+        intent: intent,
+        link: link,
+        chat: null,
+        chatId: uuid(),
+        role: "bot",
+        timestamp: Timestamp.now(),
+      };
+    } else {
+      chatData = {
+        intent: intent,
+        video: fileLink,
+        chat: null,
+        chatId: uuid(),
+        role: "bot",
+        timestamp: Timestamp.now(),
+      };
+    }
+  } else if (files.includes(fileExtension)) {
+    if (response === link) {
+      chatData = {
+        intent: intent,
+        link: link,
+        chat: null,
+        chatId: uuid(),
+        role: "bot",
+        timestamp: Timestamp.now(),
+      };
+    } else {
+      chatData = {
+        intent: intent,
+        file: fileName,
+        fileLink: fileLink,
+        fileType: fileExtension,
+        chat: null,
+        chatId: uuid(),
+        role: "bot",
+        timestamp: Timestamp.now(),
+      };
+    }
+  }
+  return chatData;
+};

--- a/src/utils/extract-link.ts
+++ b/src/utils/extract-link.ts
@@ -32,3 +32,32 @@ export const extractLink = (
   }
   return { link: "", linkMessage: null, text: input.trim() };
 };
+
+export const extractMultipleLink = (
+  input: string,
+): { link: string; fileLink: string; linkMessage?: string | null } => {
+  const fileLinkRegex = /\[=(.*?)=]/;
+  const fileLinkMatch = input.match(fileLinkRegex);
+
+  const regularLinkRegex = /{=([^{}]+)=}/;
+  const regularLinkMatch = input.match(regularLinkRegex);
+
+  const regularLinkMessageRegex = /<([^<>]+)>/;
+  const regularLinkMessageMatch = input.match(regularLinkMessageRegex);
+
+  if (
+    fileLinkMatch &&
+    ((regularLinkMatch && regularLinkMessageMatch) || regularLinkMatch)
+  ) {
+    const fileLink = fileLinkMatch[1];
+
+    const link = input
+      .replace(/<(.+?)>{=(.+?)=}/g, (_match, text, url) => {
+        return `<a class="font-semibold text-primary dark:text-secondary hover:underline" href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+      })
+      .replace(fileLinkRegex, "");
+
+    return { link, fileLink };
+  }
+  return { link: "", fileLink: "", linkMessage: null };
+};


### PR DESCRIPTION
# Type of Change

<!-- Check what's necessary or check all if applicable. -->

- [ ] BREAKING CHANGE (change that would cause existing functionality to not work as expected)
- [x] Feature (change that implements a new feature)
- [x] Bug Fix (change that fixed a bug)
- [x] Improvements (change that improves existing features or performance)
- [ ] Documentation (change in documents)
- [ ] Chore (formatting, refactoring, styling or other operations commit)

###

# Description

Fix bot response that cannot handle both link and file in a single response. Added new utility functions and statements for this.

###

# Related Tickets

- Resolves #237 